### PR TITLE
Save map on exception

### DIFF
--- a/src/mapper_node.cpp
+++ b/src/mapper_node.cpp
@@ -32,12 +32,12 @@ PM::TransformationParameters robotPoseToSet;
 PM::TransformationParameters previousRobotToMap;
 ros::Time previousTimeStamp;
 
-std::string appendToFilePath(const std::string& filePath, const std::string& appendix)
+std::string appendToFilePath(const std::string& filePath, const std::string& suffix)
 {
 	std::string::size_type const ext_pos(filePath.find_last_of('.'));
 	std::string map_path_without_extension = filePath.substr(0, ext_pos);
 
-	return map_path_without_extension.append(appendix);
+	return map_path_without_extension.append(suffix);
 }
 
 void saveMap(const std::string& mapFileName)

--- a/src/mapper_node.cpp
+++ b/src/mapper_node.cpp
@@ -32,6 +32,14 @@ PM::TransformationParameters robotPoseToSet;
 PM::TransformationParameters previousRobotToMap;
 ros::Time previousTimeStamp;
 
+std::string appendToFilePath(const std::string& filePath, const std::string& appendix)
+{
+	std::string::size_type const ext_pos(filePath.find_last_of('.'));
+	std::string map_path_without_extension = filePath.substr(0, ext_pos);
+
+	return map_path_without_extension.append(appendix);
+}
+
 void saveMap(const std::string& mapFileName)
 {
 	ROS_INFO("Saving map to %s", mapFileName.c_str());
@@ -116,8 +124,8 @@ void gotInput(const PM::DataPoints& input, const std::string& sensorFrame, const
 			ROS_ERROR_STREAM("Unable to process input: " << e.what());
 			try
 			{
-				saveTrajectory("convergence_error_traj.vtk");
-				saveMap("convergence_error_map.vtk");
+				saveTrajectory(appendToFilePath(params->finalMapFileName, "_convergence_error.vtk"));
+				saveMap(appendToFilePath(params->finalTrajectoryFileName, "_convergence_error.vtk"));
 			}
 			catch(const std::runtime_error& e)
 			{

--- a/src/mapper_node.cpp
+++ b/src/mapper_node.cpp
@@ -124,8 +124,8 @@ void gotInput(const PM::DataPoints& input, const std::string& sensorFrame, const
 			ROS_ERROR_STREAM("Unable to process input: " << e.what());
 			try
 			{
-				saveTrajectory(appendToFilePath(params->finalMapFileName, "_convergence_error.vtk"));
-				saveMap(appendToFilePath(params->finalTrajectoryFileName, "_convergence_error.vtk"));
+				saveTrajectory(appendToFilePath(params->finalTrajectoryFileName, "_convergence_error.vtk"));
+				saveMap(appendToFilePath(params->finalMapFileName, "_convergence_error.vtk"));
 			}
 			catch(const std::runtime_error& e)
 			{

--- a/src/mapper_node.cpp
+++ b/src/mapper_node.cpp
@@ -34,10 +34,11 @@ ros::Time previousTimeStamp;
 
 std::string appendToFilePath(const std::string& filePath, const std::string& suffix)
 {
-	std::string::size_type const ext_pos(filePath.find_last_of('.'));
-	std::string map_path_without_extension = filePath.substr(0, ext_pos);
+	std::string::size_type const extensionPosition(filePath.find_last_of('.'));
+	std::string mapPathWithoutExtension = filePath.substr(0, extensionPosition);
+	std::string extension = filePath.substr(extensionPosition, filePath.length()-1);
 
-	return map_path_without_extension.append(suffix);
+	return mapPathWithoutExtension + suffix + extension;
 }
 
 void saveMap(const std::string& mapFileName)
@@ -119,17 +120,17 @@ void gotInput(const PM::DataPoints& input, const std::string& sensorFrame, const
 			mapper->processInput(input, sensorToMapBeforeUpdate,
 								 std::chrono::time_point<std::chrono::steady_clock>(std::chrono::nanoseconds(timeStamp.toNSec())));
 		}
-		catch (const PM::ConvergenceError& e)
+		catch (const PM::ConvergenceError& convergenceError)
 		{
-			ROS_ERROR_STREAM("Unable to process input: " << e.what());
+			ROS_ERROR_STREAM("Unable to process input: " << convergenceError.what());
 			try
 			{
-				saveTrajectory(appendToFilePath(params->finalTrajectoryFileName, "_convergence_error.vtk"));
-				saveMap(appendToFilePath(params->finalMapFileName, "_convergence_error.vtk"));
+				saveTrajectory(appendToFilePath(params->finalTrajectoryFileName, "_convergence_error"));
+				saveMap(appendToFilePath(params->finalMapFileName, "_convergence_error"));
 			}
-			catch(const std::runtime_error& e)
+			catch(const std::runtime_error& runtimeError)
 			{
-				ROS_ERROR_STREAM("Unable to save: " << e.what());
+				ROS_ERROR_STREAM("Unable to save: " << runtimeError.what());
 			}
 			throw;
 		}


### PR DESCRIPTION
When an ICP convergence exception is thrown, save the latest map and trajectory in the path given in `final_map_file_name` and `final_trajectory_file_name` parameters (with a suffix).