### PR TITLE
Map voxel compression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,248 @@
+# Created by https://www.toptal.com/developers/gitignore/api/ros2,c++,macos,linux,visualstudiocode,jetbrains
+# Edit at https://www.toptal.com/developers/gitignore?templates=ros2,c++,macos,linux,visualstudiocode,jetbrains
+
+### C++ ###
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+### JetBrains ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### JetBrains Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# *.iml
+# modules.xml
+# .idea/misc.xml
+# *.ipr
+
+# Sonarlint plugin
+# https://plugins.jetbrains.com/plugin/7973-sonarlint
+.idea/**/sonarlint/
+
+# SonarQube Plugin
+# https://plugins.jetbrains.com/plugin/7238-sonarqube-community-plugin
+.idea/**/sonarIssues.xml
+
+# Markdown Navigator plugin
+# https://plugins.jetbrains.com/plugin/7896-markdown-navigator-enhanced
+.idea/**/markdown-navigator.xml
+.idea/**/markdown-navigator-enh.xml
+.idea/**/markdown-navigator/
+
+# Cache file creation bug
+# See https://youtrack.jetbrains.com/issue/JBR-2257
+.idea/$CACHE_FILE$
+
+# CodeStream plugin
+# https://plugins.jetbrains.com/plugin/12206-codestream
+.idea/codestream.xml
+
+# Azure Toolkit for IntelliJ plugin
+# https://plugins.jetbrains.com/plugin/8053-azure-toolkit-for-intellij
+.idea/**/azureSettings.xml
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+### ROS2 ###
+install/
+log/
+build/
+
+# Ignore generated docs
+*.dox
+*.wikidoc
+
+# eclipse stuff
+.project
+.cproject
+
+# qcreator stuff
+CMakeLists.txt.user
+
+srv/_*.py
+*.pcd
+*.pyc
+qtcreator-*
+*.user
+
+
+# Emacs
+.#*
+
+# Colcon custom files
+COLCON_IGNORE
+AMENT_IGNORE
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+# End of https://www.toptal.com/developers/gitignore/api/ros2,c++,macos,linux,visualstudiocode,jetbrains

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(norlab_icp_mapper CONFIG 2.1.0 REQUIRED)
 find_package(libpointmatcher_ros 2.0.1 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(OpenMP REQUIRED)
+find_package(libpointmatcher CONFIG 1.4.3 REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
     "srv/SaveTrajectory.srv"
@@ -27,6 +28,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
 
 include_directories(
     ${norlab_icp_mapper_INCLUDE_DIRS}
+    ${libpointmatcher_INCLUDE_DIRS}
 )
 
 add_executable(mapper_node
@@ -51,6 +53,7 @@ ament_target_dependencies(mapper_node
 target_compile_options(mapper_node PRIVATE ${OpenMP_CXX_FLAGS})
 target_link_libraries(mapper_node
     ${norlab_icp_mapper_LIBRARIES}
+    ${libpointmatcher_LIBRARIES}
     OpenMP::OpenMP_CXX
 )
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ Check the [mapper's documentation](https://norlab-icp-mapper.readthedocs.io/en/l
 | expected_unique_deskewing_TF_number |                    How much memory should we reserve for the per-point transformations.                     |       A positive integer       |                            4000                            |
 |     deskewing_round_to_nanosecs     |           How much should each point's timestamp be rounded for deskewing transformation search.            |       A positive integer       |                           50000                            |
 
+## Dynamic Node Parameters
+
+These parameters can be changed at runtime using the ROS parameter server.
+
+|          Name          |                                     Description                                      |    Possible values    | Default Value |
+| :--------------------: | :----------------------------------------------------------------------------------: | :-------------------: | :-----------: |
+| compression_voxel_size | Size of a voxel in the octree tree of the output map point cloud message. 0=disabled | A non-negative double |      0.5      |
+
 ## Node Topics
 
 |           Name           |                            Description                             |

--- a/launch/mapper.launch.py
+++ b/launch/mapper.launch.py
@@ -16,6 +16,17 @@ def generate_launch_description():
                 executable="mapper_node",
                 name="mapper_node",
                 output="screen",
+                arguments=[
+                    "--ros-args",
+                    "--log-level",
+                    "debug",
+                    "--log-level",
+                    "rcl:=INFO",
+                    "--log-level",
+                    "rmw_fastrtps_cpp:=INFO",
+                    "--log-level",
+                    "rclcpp:=INFO",
+                ],
                 parameters=[
                     {
                         "use_sim_time": True,
@@ -38,6 +49,7 @@ def generate_launch_description():
                         "is_3D": True,
                         "save_map_cells_on_hard_drive": True,
                         "publish_tfs_between_registrations": True,
+                        "compression_voxel_size": 0.2,
                     }
                 ],
                 remappings=[

--- a/src/NodeParameters.cpp
+++ b/src/NodeParameters.cpp
@@ -134,9 +134,9 @@ void NodeParameters::validateParameters() const
             }
 	}
 
-	if (compressionVoxelSize <= 0)
+	if (compressionVoxelSize < 0)
 	{
-		throw std::runtime_error("Compression voxel size must be positive: " + std::to_string(compressionVoxelSize));
+		throw std::runtime_error("Compression voxel size must be non-negative: " + std::to_string(compressionVoxelSize));
 	}
 
 }

--- a/src/NodeParameters.cpp
+++ b/src/NodeParameters.cpp
@@ -30,6 +30,8 @@ void NodeParameters::declareParameters(rclcpp::Node& node)
     node.declare_parameter<int>("expected_unique_deskewing_TF_number", 4000);
     node.declare_parameter<int>("deskewing_round_to_nanosecs", 50000);
     node.declare_parameter<bool>("localizing", true);
+    node.declare_parameter<float>("compression_voxel_size", 0.5);
+
 }
 
 void NodeParameters::retrieveParameters(rclcpp::Node& node)
@@ -53,6 +55,7 @@ void NodeParameters::retrieveParameters(rclcpp::Node& node)
 	node.get_parameter("expected_unique_deskewing_TF_number", expectedUniqueDeskewingTFNumber);
 	node.get_parameter("deskewing_round_to_nanosecs", deskewingRoundToNanoSecs);
 	node.get_parameter("localizing", localizing);
+	node.get_parameter("compression_voxel_size", compressionVoxelSize);
 }
 
 void NodeParameters::validateParameters() const
@@ -130,6 +133,12 @@ void NodeParameters::validateParameters() const
                 throw std::runtime_error("Deskewing round to nsecs value must be positive: " + std::to_string(deskewingRoundToNanoSecs));
             }
 	}
+
+	if (compressionVoxelSize <= 0)
+	{
+		throw std::runtime_error("Compression voxel size must be positive: " + std::to_string(compressionVoxelSize));
+	}
+
 }
 
 void NodeParameters::parseComplexParameters()

--- a/src/NodeParameters.h
+++ b/src/NodeParameters.h
@@ -37,6 +37,8 @@ public:
 	int deskewingRoundToNanoSecs;
 	bool localizing;
 
+	float compressionVoxelSize;
+
 	NodeParameters(rclcpp::Node& node);
 };
 

--- a/src/NodeParameters.h
+++ b/src/NodeParameters.h
@@ -37,7 +37,7 @@ public:
 	int deskewingRoundToNanoSecs;
 	bool localizing;
 
-	float compressionVoxelSize;
+	double compressionVoxelSize;
 
 	NodeParameters(rclcpp::Node& node);
 };

--- a/src/mapper_node.cpp
+++ b/src/mapper_node.cpp
@@ -416,7 +416,7 @@ private:
         PM::DataPoints newMap;
         while(rclcpp::ok())
         {
-            if(mapper->getNewLocalMap(newMap))
+            if(mapper->getNewLocalMap(newMap) && mapPublisher->get_subscription_count() > 0)
             {
                 if (params->compressionVoxelSize > 0)
                 {

--- a/src/mapper_node.cpp
+++ b/src/mapper_node.cpp
@@ -133,6 +133,15 @@ public:
         paramCallbackHandle = this->get_node_parameters_interface()->add_on_set_parameters_callback(
             std::bind(&MapperNode::updateCompressionVoxelSize, this, std::placeholders::_1));
 
+        // Initial map voxel subsampling
+        voxel_filter =
+            PM::get().DataPointsFilterRegistrar.create(
+				"OctreeGridDataPointsFilter",
+				{
+				{"maxSizeByNode", PointMatcherSupport::toParam(params->compressionVoxelSize)}
+				}
+            );
+
     }
 
 private:
@@ -173,6 +182,8 @@ private:
     std::thread mapTfPublisherThread;
 
     std::shared_ptr<rclcpp::node_interfaces::OnSetParametersCallbackHandle> paramCallbackHandle;
+
+    std::shared_ptr<PM::DataPointsFilter> voxel_filter;
 
     bool isLocalizing;
     std::mutex isLocalizingLock;
@@ -407,6 +418,16 @@ private:
         {
             if(mapper->getNewLocalMap(newMap))
             {
+                if (params->compressionVoxelSize > 0)
+                {
+                    int origNumPoints = newMap.getNbPoints();
+                    std::chrono::steady_clock::time_point mapMessageSubsamplingStartTime = std::chrono::steady_clock::now();
+                    voxel_filter->inPlaceFilter(newMap);
+                    std::chrono::steady_clock::time_point mapMessageSubsamplingEndTime = std::chrono::steady_clock::now();
+                    RCLCPP_DEBUG_STREAM(this->get_logger(), "Output map subsampled to: " << 100.0*(newMap.getNbPoints() / (double) origNumPoints)
+                        << " % in " << std::chrono::duration_cast<std::chrono::milliseconds>(mapMessageSubsamplingEndTime - mapMessageSubsamplingStartTime).count() << " [ms]");
+                }
+
                 sensor_msgs::msg::PointCloud2 mapMsgOut = PointMatcher_ROS::pointMatcherCloudToRosMsg<float>(newMap, "map", this->get_clock()->now());
                 mapPublisher->publish(mapMsgOut);
             }
@@ -558,6 +579,14 @@ private:
                 {
                     RCLCPP_DEBUG_STREAM(this->get_logger(), "Setting voxel size to: " << voxelSize);
                     params->compressionVoxelSize = voxelSize;
+
+                    voxel_filter =
+                        PM::get().DataPointsFilterRegistrar.create(
+           					"OctreeGridDataPointsFilter",
+           					{
+          						{"maxSizeByNode", PointMatcherSupport::toParam(params->compressionVoxelSize)}
+           					}
+                        );
                     result.successful = true;
                     result.reason = "Voxel size updated successfully.";
                 }

--- a/src/mapper_node.cpp
+++ b/src/mapper_node.cpp
@@ -130,9 +130,8 @@ public:
         isLocalizingLock.unlock();
 
         // Initialize parameter callback handle
-        paramSubscriber = std::make_shared<rclcpp::ParameterEventHandler>(this);
-        paramCallbackHandle = paramSubscriber->add_parameter_callback( // TODO find a way to move this to NodeParameters.cpp
-            "compression_voxel_size", std::bind(&MapperNode::updateCompressionVoxelSize, this, std::placeholders::_1));
+        paramCallbackHandle = this->get_node_parameters_interface()->add_on_set_parameters_callback(
+            std::bind(&MapperNode::updateCompressionVoxelSize, this, std::placeholders::_1));
 
     }
 
@@ -173,8 +172,7 @@ private:
     std::thread mapPublisherThread;
     std::thread mapTfPublisherThread;
 
-    std::shared_ptr<rclcpp::ParameterEventHandler> paramSubscriber;
-    std::shared_ptr<rclcpp::ParameterCallbackHandle> paramCallbackHandle;
+    std::shared_ptr<rclcpp::node_interfaces::OnSetParametersCallbackHandle> paramCallbackHandle;
 
     bool isLocalizing;
     std::mutex isLocalizingLock;
@@ -539,22 +537,33 @@ private:
         }
     }
 
-    void updateCompressionVoxelSize(const rclcpp::Parameter& param)
+    rcl_interfaces::msg::SetParametersResult updateCompressionVoxelSize(const std::vector<rclcpp::Parameter>& updatedParams)
     {
-        if (param.get_type() == rclcpp::ParameterType::PARAMETER_DOUBLE)
-        {
-            double voxelSize = param.as_double();
+        rcl_interfaces::msg::SetParametersResult result;
 
-            if (voxelSize < 0)
+        for (const auto& param : updatedParams)
+        {
+            // TODO find a way to move this to NodeParameters.cpp or sync the param name across files
+            if (param.get_name() == "compression_voxel_size" && param.get_type() == rclcpp::ParameterType::PARAMETER_DOUBLE)
             {
-                RCLCPP_WARN_STREAM(this->get_logger(), "Invalid voxel size. Must be non-negative: " << voxelSize);
-            }
-            else
-            {
-                RCLCPP_DEBUG_STREAM(this->get_logger(), "Setting voxel size to: " << voxelSize);
-                params->compressionVoxelSize = voxelSize;
+                double voxelSize = param.as_double();
+
+                if (voxelSize < 0)
+                {
+                    RCLCPP_WARN_STREAM(this->get_logger(), "Invalid voxel size. Must be non-negative: " << voxelSize);
+                    result.successful = false;
+                    result.reason = "Invalid voxel size. Must be non-negative.";
+                }
+                else
+                {
+                    RCLCPP_DEBUG_STREAM(this->get_logger(), "Setting voxel size to: " << voxelSize);
+                    params->compressionVoxelSize = voxelSize;
+                    result.successful = true;
+                    result.reason = "Voxel size updated successfully.";
+                }
             }
         }
+        return result;
     }
 
 };

--- a/src/mapper_node.cpp
+++ b/src/mapper_node.cpp
@@ -561,6 +561,7 @@ private:
     rcl_interfaces::msg::SetParametersResult updateCompressionVoxelSize(const std::vector<rclcpp::Parameter>& updatedParams)
     {
         rcl_interfaces::msg::SetParametersResult result;
+        result.successful = true;
 
         for (const auto& param : updatedParams)
         {
@@ -587,7 +588,6 @@ private:
           						{"maxSizeByNode", PointMatcherSupport::toParam(params->compressionVoxelSize)}
            					}
                         );
-                    result.successful = true;
                     result.reason = "Voxel size updated successfully.";
                 }
             }

--- a/src/mapper_node.cpp
+++ b/src/mapper_node.cpp
@@ -134,7 +134,7 @@ public:
             std::bind(&MapperNode::updateCompressionVoxelSize, this, std::placeholders::_1));
 
         // Initial map voxel subsampling
-        voxel_filter =
+        outputMapSubsamplingFilter =
             PM::get().DataPointsFilterRegistrar.create(
 				"OctreeGridDataPointsFilter",
 				{
@@ -183,7 +183,7 @@ private:
 
     std::shared_ptr<rclcpp::node_interfaces::OnSetParametersCallbackHandle> paramCallbackHandle;
 
-    std::shared_ptr<PM::DataPointsFilter> voxel_filter;
+    std::shared_ptr<PM::DataPointsFilter> outputMapSubsamplingFilter;
 
     bool isLocalizing;
     std::mutex isLocalizingLock;
@@ -422,7 +422,7 @@ private:
                 {
                     int origNumPoints = newMap.getNbPoints();
                     std::chrono::steady_clock::time_point mapMessageSubsamplingStartTime = std::chrono::steady_clock::now();
-                    voxel_filter->inPlaceFilter(newMap);
+                    outputMapSubsamplingFilter->inPlaceFilter(newMap);
                     std::chrono::steady_clock::time_point mapMessageSubsamplingEndTime = std::chrono::steady_clock::now();
                     RCLCPP_DEBUG_STREAM(this->get_logger(), "Output map subsampled to: " << 100.0*(newMap.getNbPoints() / (double) origNumPoints)
                         << " % in " << std::chrono::duration_cast<std::chrono::milliseconds>(mapMessageSubsamplingEndTime - mapMessageSubsamplingStartTime).count() << " [ms]");
@@ -580,7 +580,7 @@ private:
                     RCLCPP_DEBUG_STREAM(this->get_logger(), "Setting voxel size to: " << voxelSize);
                     params->compressionVoxelSize = voxelSize;
 
-                    voxel_filter =
+                    outputMapSubsamplingFilter =
                         PM::get().DataPointsFilterRegistrar.create(
            					"OctreeGridDataPointsFilter",
            					{

--- a/src/mapper_node.cpp
+++ b/src/mapper_node.cpp
@@ -14,6 +14,7 @@
 #include <mutex>
 #include <thread>
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
+#include <pointmatcher/PointMatcher.h>
 
 class MapperNode : public rclcpp::Node
 {
@@ -127,6 +128,12 @@ public:
             isLocalizing = true;
         }
         isLocalizingLock.unlock();
+
+        // Initialize parameter callback handle
+        paramSubscriber = std::make_shared<rclcpp::ParameterEventHandler>(this);
+        paramCallbackHandle = paramSubscriber->add_parameter_callback( // TODO find a way to move this to NodeParameters.cpp
+            "compression_voxel_size", std::bind(&MapperNode::updateCompressionVoxelSize, this, std::placeholders::_1));
+
     }
 
 private:
@@ -165,6 +172,9 @@ private:
     rclcpp::Service<std_srvs::srv::Empty>::SharedPtr disableLocalizationService;
     std::thread mapPublisherThread;
     std::thread mapTfPublisherThread;
+
+    std::shared_ptr<rclcpp::ParameterEventHandler> paramSubscriber;
+    std::shared_ptr<rclcpp::ParameterCallbackHandle> paramCallbackHandle;
 
     bool isLocalizing;
     std::mutex isLocalizingLock;
@@ -528,6 +538,25 @@ private:
             setRobotPose(PointMatcher_ROS::rosMsgToPointMatcherTransformation<float>(poseMsgIn.pose.pose, homogeneousDim));
         }
     }
+
+    void updateCompressionVoxelSize(const rclcpp::Parameter& param)
+    {
+        if (param.get_type() == rclcpp::ParameterType::PARAMETER_DOUBLE)
+        {
+            double voxelSize = param.as_double();
+
+            if (voxelSize < 0)
+            {
+                RCLCPP_WARN_STREAM(this->get_logger(), "Invalid voxel size. Must be non-negative: " << voxelSize);
+            }
+            else
+            {
+                RCLCPP_DEBUG_STREAM(this->get_logger(), "Setting voxel size to: " << voxelSize);
+                params->compressionVoxelSize = voxelSize;
+            }
+        }
+    }
+
 };
 
 int main(int argc, char** argv)


### PR DESCRIPTION
Added a dynamic ROS2 parameter called `compression_voxel_size` that controls if the output map point cloud message is downsampled.

Additionally, the map is now only published if there is at least one active subscriber, saving some processing power.

The new parameter name `compression_voxel_size` is currently hardcoded at two places, which is not ideal, but it comes from the current implementation of the NodeParameters class and how parameter callbacks work.